### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
 # CMHTMLView
 
 [![Build Status](https://secure.travis-ci.org/mureev/CMHTMLView.png?branch=master)](http://travis-ci.org/mureev/CMHTMLView)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/v/CMHTMLView/badge.png)](http://cocoapods.org/?q=name%3Acmhtmlview%2A)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/p/CMHTMLView/badge.png)](http://cocoapods.org/?q=name%3Acmhtmlview%2A)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/CMHTMLView/badge.png)](http://cocoapods.org/?q=name%3Acmhtmlview%2A)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/p/CMHTMLView/badge.png)](http://cocoapods.org/?q=name%3Acmhtmlview%2A)
 ![License MIT](https://go-shields.herokuapp.com/license-MIT-blue.png)
 
 ##Deep refactoring completed. Expected API freeze - March 2014. You can use previous version with old API - 0.0.1.


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
